### PR TITLE
Fix frame not being int on blender 2.93.5

### DIFF
--- a/Plugin/io_export_s64_charexport.py
+++ b/Plugin/io_export_s64_charexport.py
@@ -397,7 +397,7 @@ def setupData(self, object, skeletonList, meshList, settingsList):
                     s.animation_data.action = actionbefore
                 
             # Fix the frame number
-            bpy.context.scene.frame_set(framebefore)
+            bpy.context.scene.frame_set(int(framebefore))
             if (isNewBlender()):
                 bpy.context.view_layer.update()
             else:

--- a/Plugin/io_export_s64_charexport.py
+++ b/Plugin/io_export_s64_charexport.py
@@ -346,7 +346,7 @@ def setupData(self, object, skeletonList, meshList, settingsList):
             for k in anim.frames:
 
                 # Modify the current Blender keyframe so we can get the pose data
-                bpy.context.scene.frame_set(k)
+                bpy.context.scene.frame_set(int(k))
 
                 # Go through all skeletons and add the bone's data
                 for s in skeletonList:


### PR DESCRIPTION
Blender 2.93.5 complains that frame value is a float and not an int when calling `bpy.context.scene.frame_set`, this pull request explicitly converts the frame variable to an int.